### PR TITLE
Allow more complicated post-pip-install setup sequences

### DIFF
--- a/bazel_python.bzl
+++ b/bazel_python.bzl
@@ -116,7 +116,7 @@ bazel_python_venv = rule(
         "python_version": attr.string(),
         "requirements_file": attr.label(allow_single_file = True),
         "run_after_pip": attr.string(),
-        "run_after_pip_srcs": attr.label(),
+        "run_after_pip_srcs": attr.label_list(),
     },
 )
 

--- a/bazel_python.bzl
+++ b/bazel_python.bzl
@@ -105,7 +105,7 @@ def _bazel_python_venv_impl(ctx):
     """
     ctx.actions.run_shell(
         command = command.format(py_dir = python_dir, out_dir = venv_dir.path),
-        inputs = inputs,
+        inputs = inputs + ctx.attr.run_after_pip_srcs,
         outputs = [venv_dir],
     )
     return [DefaultInfo(files = depset([venv_dir]))]
@@ -116,6 +116,7 @@ bazel_python_venv = rule(
         "python_version": attr.string(),
         "requirements_file": attr.label(allow_single_file = True),
         "run_after_pip": attr.string(),
+        "run_after_pip_srcs": attr.label(),
     },
 )
 

--- a/bazel_python.bzl
+++ b/bazel_python.bzl
@@ -94,6 +94,8 @@ def _bazel_python_venv_impl(ctx):
     if ctx.attr.requirements_file:
         command += "pip3 install -r " + ctx.file.requirements_file.path
         inputs.append(ctx.file.requirements_file)
+    for src in ctx.attr.run_after_pip_srcs:
+        inputs.extend(src.files.to_list())
     command += ctx.attr.run_after_pip
     command += """
         REPLACEME=$PWD/'{out_dir}'
@@ -105,7 +107,7 @@ def _bazel_python_venv_impl(ctx):
     """
     ctx.actions.run_shell(
         command = command.format(py_dir = python_dir, out_dir = venv_dir.path),
-        inputs = inputs + ctx.attr.run_after_pip_srcs,
+        inputs = inputs,
         outputs = [venv_dir],
     )
     return [DefaultInfo(files = depset([venv_dir]))]
@@ -116,7 +118,7 @@ bazel_python_venv = rule(
         "python_version": attr.string(),
         "requirements_file": attr.label(allow_single_file = True),
         "run_after_pip": attr.string(),
-        "run_after_pip_srcs": attr.label_list(),
+        "run_after_pip_srcs": attr.label_list(allow_files = True),
     },
 )
 


### PR DESCRIPTION
There's always been an option to run arbitrary code after the pip install step in order to set up the Python venv. However, that code could not use any other files from the current repository (so it was only useful for, e.g., downloading and installing something). This PR adds a new option, `run_after_pip_srcs`, which allows the user to specify a set of files which will be available to their post-install script.

I am using this to build + install a C++ module inside the venv.