### PR TITLE
Add a Warn-Only mode that falls back on the system Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ the repository for which you want to compute coverage. To use it, after running
 `bazel test //...` you should be able to run `bazel run coverage_report` to
 produce an `htmlcov` directory with the coverage report.
 
+#### Selectively Disabling Bazel-Python
+In some scenarios, it may suffice to use the system Python. For example, if a
+backend server only needs Python for one or two setup operations. In this case,
+one may pass `--define BAZEL_PYTHON_ONLY_WARN=true` to instruct Bazel-Python to
+fallback on the system Python installation if a version-specific one is not
+found. It will still print a debug message, but will not fail the build.
+
 ## Known Issues
 #### Missing Modules
 If you get errors about missing modules (e.g., `pytest not found`), please

--- a/bazel_python.bzl
+++ b/bazel_python.bzl
@@ -73,8 +73,13 @@ def _bazel_python_venv_impl(ctx):
 
     Also installs requirements specified by @ctx.attr.requirements_file.
     """
+    use_system = False
     if "BAZEL_PYTHON_DIR" not in ctx.var:
-        fail("You must run setup_python.sh for " + ctx.attr.python_version)
+        if "BAZEL_PYTHON_ONLY_WARN" in ctx.var:
+            print("A bazel-python installation was not found. Falling back to the system python. For reproducibility, please run setup_python.sh for " + ctx.attr.python_version)
+            use_system = True
+        else:
+            fail("You must run setup_python.sh for " + ctx.attr.python_version)
     python_parent_dir = ctx.var.get("BAZEL_PYTHON_DIR")
     python_version = ctx.attr.python_version
     python_dir = python_parent_dir + "/" + python_version
@@ -82,12 +87,17 @@ def _bazel_python_venv_impl(ctx):
     # TODO: Fail if python_dir does not exist.
     venv_dir = ctx.actions.declare_directory("bazel_python_venv_installed")
     inputs = []
-    command = """
-        export PATH={py_dir}/bin:$PATH
-        export PATH={py_dir}/include:$PATH
-        export PATH={py_dir}/lib:$PATH
-        export PATH={py_dir}/share:$PATH
-        export PYTHON_PATH={py_dir}:{py_dir}/bin:{py_dir}/include:{py_dir}/lib:{py_dir}/share
+    if use_system:
+        command = ""
+    else:
+        command = """
+            export PATH={py_dir}/bin:$PATH
+            export PATH={py_dir}/include:$PATH
+            export PATH={py_dir}/lib:$PATH
+            export PATH={py_dir}/share:$PATH
+            export PYTHON_PATH={py_dir}:{py_dir}/bin:{py_dir}/include:{py_dir}/lib:{py_dir}/share
+        """
+    command += """
         python3 -m venv {out_dir} || exit 1
         source {out_dir}/bin/activate || exit 1
     """

--- a/bazel_python.bzl
+++ b/bazel_python.bzl
@@ -73,17 +73,20 @@ def _bazel_python_venv_impl(ctx):
 
     Also installs requirements specified by @ctx.attr.requirements_file.
     """
+    python_version = ctx.attr.python_version
     use_system = False
     only_warn = ctx.var.get("BAZEL_PYTHON_ONLY_WARN", "false").lower() == "true"
     if "BAZEL_PYTHON_DIR" not in ctx.var:
         if only_warn:
-            print("A bazel-python installation was not found. Falling back to the system python. For reproducibility, please run setup_python.sh for " + ctx.attr.python_version)
+            print("A bazel-python installation was not found. Falling back to the system python. For reproducibility, please run setup_python.sh for " + python_version)
             use_system = True
         else:
-            fail("You must run setup_python.sh for " + ctx.attr.python_version)
-    python_parent_dir = ctx.var.get("BAZEL_PYTHON_DIR")
-    python_version = ctx.attr.python_version
-    python_dir = python_parent_dir + "/" + python_version
+            fail("You must run setup_python.sh for " + python_version)
+    if use_system:
+        python_dir = ""
+    else:
+        python_parent_dir = ctx.var.get("BAZEL_PYTHON_DIR")
+        python_dir = python_parent_dir + "/" + python_version
 
     # TODO: Fail if python_dir does not exist.
     venv_dir = ctx.actions.declare_directory("bazel_python_venv_installed")

--- a/bazel_python.bzl
+++ b/bazel_python.bzl
@@ -74,8 +74,9 @@ def _bazel_python_venv_impl(ctx):
     Also installs requirements specified by @ctx.attr.requirements_file.
     """
     use_system = False
+    only_warn = ctx.var.get("BAZEL_PYTHON_ONLY_WARN", "false").lower() == "true"
     if "BAZEL_PYTHON_DIR" not in ctx.var:
-        if "BAZEL_PYTHON_ONLY_WARN" in ctx.var:
+        if only_warn:
             print("A bazel-python installation was not found. Falling back to the system python. For reproducibility, please run setup_python.sh for " + ctx.attr.python_version)
             use_system = True
         else:

--- a/pywrapper.sh
+++ b/pywrapper.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 
-source bazel_python_venv_installed/bin/activate || exit 1
+# If python is run from the 'main' workspace, then we will have
+# bazel_python_venv_installed available right in the current directory. But if
+# it's run from a dependency (e.g., GRPC) then it will be under
+# bazel_out/.../[mainworkspace]. This searches for the first matching path then
+# exits, so it should be reasonably fast in most cases.
+# https://unix.stackexchange.com/questions/68414/only-find-first-few-matched-files-using-find
+venv_path=$((find . -path "*/bazel_python_venv_installed/bin/activate" & ) | head -n 1)
+# If venv_path was not found it will be empty and the below will throw an
+# error, alerting Bazel something went wrong.
+source $venv_path || exit 1
 python $@


### PR DESCRIPTION
It used to be that in [SyReNN](https://github.com/95616ARG/SyReNN) one could run `bazel test syrenn_server/...` successfully without worrying about Bazel-Python, because none of the targets in `syrenn_server/...` involved Python code.

However, after recent updates (possibly related to GRPC?) it seems a new dependency on Python has been snuck in there. Most likely related to protobufs and GRPC.

This is not an important dependency, and it is preferable to fall back on the system Python installation instead of failing the entire build.

This PR adds a new flag to support such scenarios. `BAZEL_PYTHON_WARN_ONLY=true` will cause it to print a debug message and then carry on with the system Python if such a scenario is encountered.

I'm still testing this, plan to merge with https://github.com/95616ARG/SyReNN/pull/10