### PR TITLE
Follow symlinks when looking for the activation script

### DIFF
--- a/pywrapper.sh
+++ b/pywrapper.sh
@@ -6,7 +6,7 @@
 # bazel_out/.../[mainworkspace]. This searches for the first matching path then
 # exits, so it should be reasonably fast in most cases.
 # https://unix.stackexchange.com/questions/68414/only-find-first-few-matched-files-using-find
-venv_path=$((find . -path "*/bazel_python_venv_installed/bin/activate" & ) | head -n 1)
+venv_path=$((find -L . -path "*/bazel_python_venv_installed/bin/activate" & ) | head -n 1)
 # If venv_path was not found it will be empty and the below will throw an
 # error, alerting Bazel something went wrong.
 source $venv_path || exit 1


### PR DESCRIPTION
This was causing an issue. Somehow, `bazel_python_venv_installed` was a symlink so it couldn't find `bazel_python_venv_installed/bin/activate` unless we follow the symlinks through.

The weird thing is, tests were passing in the SyReNN repo even with this bug. Maybe the symlink behavior was changed with newer Bazel or something. Weird. But this seems to fix it for me!